### PR TITLE
small fixes to prepare for CRAN submission

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -21,3 +21,5 @@
 ^R/Removed_Funs\.R$
 ^cran-comments\.md$
 ^\.github$
+^codemeta\.json$
+^README_files$

--- a/R/util.R
+++ b/R/util.R
@@ -428,7 +428,7 @@ pplr_summary_table_update <- function(){
 
 
 #' @noRd
-#' Check whether the summary table has been recently updated
+# Check whether the summary table has been recently updated
 pplr_summary_table_check = function(){
   
   wks_passed <- floor(as.numeric(difftime(Sys.time(),


### PR DESCRIPTION
This contains a couple very minor fixes to get the package ready for CRAN. It does the following:

- adds `README_files` and `codemeta.json` to `.Rbuildignore`

- removes an errant Roxygen comment for a function that is not supposed to be documented.

Check results from my branch are [here](https://travis-ci.org/levisc8/popler/builds/598195760). There shouldn't be any errors/warnings/notes, so I think it's ready for CRAN now, but there may be issues on 32-bit systems that I haven't been able to check on (or Solaris or something like that). 